### PR TITLE
Fakerの設定を本番環境では適用しないように変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,5 @@ module Furima42059
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-
-    Faker::Config.locale = :ja
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,4 +63,6 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   config.active_job.queue_adapter = :test
+
+  Faker::Config.locale = :ja
 end


### PR DESCRIPTION
# What
`config\application.rb`に記述していたFakerの設定を`config\environments\test.rb`に移動
# Why
本番環境ではインストールしていないジェム`Faker`についての設定を本番環境含む全環境での設定ファイルに記述してしまっており、デプロイ時にエラーが発生してしまっていたため